### PR TITLE
Stop oak growing instantly; Stop plum and birch overriding existing nodes

### DIFF
--- a/birch/init.lua
+++ b/birch/init.lua
@@ -79,7 +79,7 @@ local function grow_new_birch_tree(pos)
 		return
 	end
 
-	minetest.place_schematic({x = pos.x - 2, y = pos.y, z = pos.z - 2}, birch.birchtree, "0", nil, true)
+	minetest.place_schematic({x = pos.x - 2, y = pos.y, z = pos.z - 2}, birch.birchtree, "0", nil, false)
 end
 
 --

--- a/oak/init.lua
+++ b/oak/init.lua
@@ -39,7 +39,7 @@ minetest.register_node("oak:acorn", {
 local function grow_new_oak_tree(pos)
 	if not default.can_grow(pos) then
 		-- try a bit later again
-		minetest.get_node_timer(pos):start(math.random(1, 1))
+		minetest.get_node_timer(pos):start(math.random(240, 600))
 		return
 	end
 	minetest.remove_node(pos)
@@ -109,7 +109,7 @@ minetest.register_node("oak:sapling", {
 	sounds = default.node_sound_leaves_defaults(),
 
 	on_construct = function(pos)
-		minetest.get_node_timer(pos):start(math.random(1,1))
+		minetest.get_node_timer(pos):start(math.random(2400,4800))
 	end,
 
 	on_place = function(itemstack, placer, pointed_thing)
@@ -198,7 +198,7 @@ minetest.register_lbm({
 	name = "oak:convert_oak_saplings_to_node_timer",
 	nodenames = {"oak:sapling"},
 	action = function(pos)
-		minetest.get_node_timer(pos):start(math.random(1, 1))
+		minetest.get_node_timer(pos):start(math.random(1200, 2400))
 	end
 })
 

--- a/plumtree/init.lua
+++ b/plumtree/init.lua
@@ -61,7 +61,7 @@ local function grow_new_plumtree_tree(pos)
 		return
 	end
 	minetest.remove_node(pos)
-	minetest.place_schematic({x = pos.x-4, y = pos.y, z = pos.z-4}, modpath.."/schematics/plumtree.mts", "0", nil, true)
+	minetest.place_schematic({x = pos.x-4, y = pos.y, z = pos.z-4}, modpath.."/schematics/plumtree.mts", "0", nil, false)
 end
 
 --


### PR DESCRIPTION
`place_schematic` should always be called with `force = false`

Timers for oak tree have been aligned with other trees